### PR TITLE
Fix Date Showing for Future Content

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -214,8 +214,8 @@ function pmpros_pmpro_text_filter($text)
 				$day = $series->getDelayForPost($post->ID);
 				
 				$member_days = pmpro_getMemberDays($current_user->ID);
-				$days_left = $day - $member_days;
-				$date = date(get_option("date_format", strtotime("+ $days_left Days", current_time("timestamp"))));
+				$days_left = ceil($day - $member_days);
+				$date = date(get_option("date_format"), strtotime("+ $days_left Days", current_time("timestamp")));
 				
 				$text = "This content is part of the <a href='" . get_permalink($inseries) . "'>" . get_the_title($inseries) . "</a> series. You will gain access on " . $date . ".";
 			}


### PR DESCRIPTION
days left needed to be rounded up to integer for strtotime to work using
it as days, and a paren. closure error between the date and get_option
functions was causing this to always show as today's date.
