### PR TITLE
Allows user to change the subject of the email sent

### DIFF
--- a/classes/class.pmproseries.php
+++ b/classes/class.pmproseries.php
@@ -185,7 +185,8 @@ class PMProSeries
 		$post_list .= "</ul>\n";
 		
         $email->email = $user->user_email;
-        $email->subject = sprintf(__("New content is available at %s", "pmpro"), get_option("blogname"));
+        $subject = sprintf(__("New content is available at %s", "pmpro"), get_option("blogname"));
+	$email->subject = apply_filters( 'pmpros_new_content_subject', $subject, $user, $post_ids );
         $email->template = "new_content";
         
 		//check for custom email template


### PR DESCRIPTION
When new content opens up this allows the user to change the subject of the email that would get sent to the site user.

Similar to my last commit, it really would be better to include a metabox in the series and allow the user to set a subject (and the content of the email) instead of restricting this feature to developers only with a filter.
