### PR TITLE
Introduce class to series paragraph

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -120,7 +120,7 @@ function pmpros_the_content( $content ) {
 			 * @param int.   $days.   How many days a user is into the membership.
 			 *
 			 */
-			$content .= apply_filters( 'pmpros_days_into_membership', '<p class="pmpro_series_days_into_membership">' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>', intval( pmpro_getMemberDays() );
+			$content .= apply_filters( 'pmpros_days_into_membership', '<p class="pmpro_series_days_into_membership">' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>', intval( pmpro_getMemberDays() ) );
 			$content .= $series->getPostList();
 		}
 		

--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -117,9 +117,10 @@ function pmpros_the_content( $content ) {
 			 * @since 4.2
 			 *
 			 * @param string $content The content to filter/chnge.
+			 * @param int.   $days.   How many days a user is into the membership.
 			 *
 			 */
-			$content .= apply_filters( 'pmpros_days_into_membership', '<p class="pmpro_series_days_into_membership">' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>' );
+			$content .= apply_filters( 'pmpros_days_into_membership', '<p class="pmpro_series_days_into_membership">' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>', intval( pmpro_getMemberDays() );
 			$content .= $series->getPostList();
 		}
 		

--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -111,7 +111,15 @@ function pmpros_the_content( $content ) {
 		// Display the Series if Paid Memberships Pro is active.
 		if ( !function_exists( 'pmpro_has_membership_access' ) || pmpro_has_membership_access() ) {
 			$series   = new PMProSeries( $post->ID );
-			$content .= '<p>' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>';
+			/**
+			 * Filter the text for current days into the Membership.
+			 *
+			 * @since 4.2
+			 *
+			 * @param string $content The content to filter/chnge.
+			 *
+			 */
+			$content .= apply_filters( 'pmpros_days_into_membership', '<p class="pmpro_series_days_into_membership">' . sprintf( __( 'You are on day %d of your membership.', 'pmpro-series' ), intval( pmpro_getMemberDays() ) ) . '</p>' );
 			$content .= $series->getPostList();
 		}
 		


### PR DESCRIPTION
Closes #67 

This PR adds a class to the paragraph tag when showing how many days a user is into a membership so it can be adjusted via CSS.

It also adds in a new filter so that the text can be overridden.

Filter in use:
```php
function my_pmpro_series_days_into_membership( $content, $days ) {
    return '';
}
add_filter( 'pmpros_days_into_membership', 'my_pmpro_series_days_into_membership', 10, 2 );
```

And the result:

<img width="699" alt="Screen Shot 2020-02-21 at 9 46 28 AM" src="https://user-images.githubusercontent.com/636521/75049018-18b82800-548f-11ea-8ee5-b7717c0df02a.png">
