### PR TITLE
Use date_i18n instead of date

### DIFF
--- a/classes/class.pmproseries.php
+++ b/classes/class.pmproseries.php
@@ -390,7 +390,7 @@ class PMProSeries {
 
 			foreach ( $post_list_posts as $sp ) {
 				$days_left = ceil( $sp->delay - $member_days );
-				$date      = date( get_option( 'date_format' ), strtotime( "+ $days_left Days", current_time( 'timestamp' ) ) );
+				$date      = date_i18n( get_option( 'date_format' ), strtotime( "+ $days_left Days", current_time( 'timestamp' ) ) );
 				?>
 				<li class="pmpro_series_item-li-
 				<?php

--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -317,7 +317,7 @@ function pmpros_pmpro_text_filter( $text ) {
 
 				$member_days = pmpro_getMemberDays( $current_user->ID );
 				$days_left   = ceil( $day - $member_days );
-				$series_date_text        = date( get_option( 'date_format' ), strtotime( "+ $days_left Days", current_time( 'timestamp' ) ) );
+				$series_date_text        = date_i18n( get_option( 'date_format' ), strtotime( "+ $days_left Days", current_time( 'timestamp' ) ) );
 
 				$series_link_text = '<a href="' . get_permalink( $inseries ) . '">' . get_the_title( $inseries ) . '</a>';
 				$text = sprintf( __( 'This content is part of the %s series. You will gain access on %s.', 'pmpro-series' ),  $series_link_text, $series_date_text );


### PR DESCRIPTION
`date_i18n` retrieves the date in a localized format. Without this, dates will still be displayed in English even when the site language is set to another.

Closes #72.