### PR TITLE
BUG FIX: Unpublished series content emails

### DIFF
--- a/scheduled/crons.php
+++ b/scheduled/crons.php
@@ -17,6 +17,7 @@ function pmpros_check_for_new_content() {
         SELECT *
         FROM $wpdb->posts
         WHERE post_type = 'pmpro_series'
+        AND post_status = 'publish'
     ");
 
 	//store emails to send


### PR DESCRIPTION
BUG FIX: Fixed an issue where trashed/draft series content would be emailed out to members. This will now only fetch published series.