### PR TITLE
Adding MMPU compatibility

### DIFF
--- a/classes/class.pmproseries.php
+++ b/classes/class.pmproseries.php
@@ -608,10 +608,10 @@ class PMProSeries {
 		}
 
 		// If series is restricted, we need to find the maximum number of days that the user has been a member of any of the restricted levels.
-		$member_days = null;
+		$member_days = 0;
 		foreach ( $series_levels as $level_id ) {
 			$days = pmpro_getMemberDays( $user_id, $level_id );
-			if ( null === $member_days || $days > $member_days ) {
+			if ( $days > $member_days ) {
 				$member_days = $days;
 			}
 		}


### PR DESCRIPTION
Adding method `get_member_days()` on `PMProSeries` objects to get the number of days that a user has had access to the series. Considers all membership levels that the user has for MMPU compatibility.

Also cleaned up some logic around having access to a post and the "no access" message. This fixed an issue where the "available" date shown may be incorrect if a single post is in multiple series.