### PR TITLE
Fixes a PHP error that occurs for non-admins

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -544,8 +544,9 @@ function pmpros_plugin_action_links( $links ) {
 		$new_links = array(
 			'<a href="' . get_admin_url( null, 'edit.php?post_type=pmpro_series' ) . '">' . __( 'Settings', 'pmpro-series' ) . '</a>',
 		);
+		return array_merge( $new_links, $links );
 	}
-	return array_merge( $new_links, $links );
+	return $links;
 }
 add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'pmpros_plugin_action_links' );
 


### PR DESCRIPTION
Resolves #96

This was caused by the $new_links variable in the plugin action links trying to be merged into the $links array when a user was not an admin