### PR TITLE
Avada Compatibility fix for duplicate content

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -130,6 +130,24 @@ function pmpros_the_content( $content ) {
 add_filter( 'the_content', 'pmpros_the_content' );
 
 /**
+ * Adds compatibility for the Avada theme by removing our 
+ * hooks from their content
+ * 
+ * @since TBD
+ */
+function pmpros_avada_remove_content_changes_avada() {
+	remove_filter( 'the_content', 'pmpros_the_content' );
+}
+add_action( 'awb_remove_third_party_the_content_changes', 'pmpros_avada_remove_content_changes_avada', 5 );
+
+// Add the_content restriction back for Avada.
+function pmpros_avada_readd_content_changes_avada() {
+	add_filter( 'the_content', 'pmpros_the_content' );
+}
+add_action( 'awb_readd_third_party_the_content_changes', 'pmpros_avada_readd_content_changes_avada', 99 );
+
+
+/**
  * Check if a user has access to a series.
  */
 function pmpros_hasAccessToSeries( $series_id, $user_id, $return_membership_levels = false ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guideline](https://github.com/strangerstudios/paid-memberships-pro/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/paid-memberships-pro/pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avada runs the_content filter in the header and footer areas. The same compat checks we have in place apply to the Series Add On now. 

### How to test the changes in this Pull Request:

1. Set up the header and/or footer in avada to use custom content so that the_content filer runs
2. Create a series
3. View the series 
4. The series should only be added to the content of the page and not duplicated in the header and footer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?