### PR TITLE
Updating headings for a11y

### DIFF
--- a/classes/class.pmproseries.php
+++ b/classes/class.pmproseries.php
@@ -508,7 +508,7 @@ class PMProSeries {
 		<?php if ( ! empty( $this->error ) ) { ?>
 			<div class="message error"><p><?php echo $this->error; ?></p></div>
 		<?php } ?>
-		<h3><?php _e( 'Posts in this Series', 'pmpro-series' ); ?></h3>
+		<h2><?php _e( 'Posts in this Series', 'pmpro-series' ); ?></h2>
 		<table id="pmpros_table" class="wp-list-table widefat striped">
 		<thead>
 			<th><?php _e( 'Order', 'pmpro-series' ); ?></th>
@@ -542,7 +542,7 @@ class PMProSeries {
 		?>
 		</tbody>
 		</table>
-		<h3><?php _e( 'Add/Edit Posts', 'pmpro-series' ); ?></h3>
+		<h2><?php _e( 'Add/Edit Posts', 'pmpro-series' ); ?></h2>
 		<table id="newmeta" class="wp-list-table widefat striped">
 			<thead>
 				<tr>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.