### PR TITLE
Fixing "new content" emails not sending

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -203,7 +203,7 @@ function pmpros_hasAccess( $user_id, $post_id ) {
 			// Check if the user has been a part of this series long enough to view this post.
 			$series = new PMProSeries( $series_id );
 			$post_delay  = $series->getDelayForPost( $post_id );
-			$member_days = intval( $series->get_member_days() );
+			$member_days = intval( $series->get_member_days( $user_id ) );
 			if ( empty( $post_delay ) || $member_days >= $post_delay ) {
 				return true;    // user has access to this post
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

During the cron to email users about new content that they have access to, we call `pmpros_hasAccess()` to see if the user has access to a specific post yet. Part of that calculation is using the method `$series->get_member_days()`. By default, if no specific user is passed to `get_member_days()`, the method will default to the current user.

The issue here is that, during the cron, there is not a logged in user. Therefore, `pmpros_hasAccess()` will always return `false` and users will never be told that they have new content (unless the content has a delay of `0` days).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
