### PR TITLE
Series content that has a delay greater than 0 does not send an email

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -203,7 +203,7 @@ function pmpros_hasAccess( $user_id, $post_id ) {
 			// Check if the user has been a part of this series long enough to view this post.
 			$series = new PMProSeries( $series_id );
 			$post_delay  = $series->getDelayForPost( $post_id );
-			$member_days = intval( $series->get_member_days() );
+			$member_days = intval( $series->get_member_days( $user_id ) );
 			if ( empty( $post_delay ) || $member_days >= $post_delay ) {
 				return true;    // user has access to this post
 			}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Series content that has a delay greater than 0 does not send an email due to a missing $user_id variable. We default to the 'current user' when this is empty but there never is a current user when we're in a cron

### How to test the changes in this Pull Request:

1. Create a series with posts that have delays greater than 0
2. The cron should send the new content email as new content becomes available

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

