### PR TITLE
Avada compatibility fix

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -134,9 +134,9 @@ function pmpros_the_content( $content ) {
 				</div> <!-- end pmpro_card -->
 			</div> <!-- end pmpro -->
 			<?php
+			$content = ob_get_contents();
+			ob_end_clean();
 		}
-		$content = ob_get_contents();
-		ob_end_clean();
 
 		// Note: Let's eventually work to make this compatible if Paid Memberships Pro is not active.		
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes an issue that occurs on the Series edit page when Avada Builder and Yoast SEO are active

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->