### PR TITLE
[BUGFIXING] Add missing help text to New Series Content Notification …

### DIFF
--- a/pmpro-series.php
+++ b/pmpro-series.php
@@ -516,6 +516,7 @@ function pmpros_email_templates( $templates ) {
 		'subject'     => esc_html__( 'New content is available at !!sitename!!', 'pmpro-series' ),
 		'description' => esc_html__( 'New Series Content Notification', 'pmpro-series' ),
 		'body'        => file_get_contents( dirname( __FILE__ ) . '/email/new_content.html' ),
+		'help_text'   => esc_html__( 'This email is sent to users when new content is available in a series.', 'pmpro-series' ),
 	);
 	return $templates;
 }


### PR DESCRIPTION
…email template

 * just that

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-pay-by-check/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-pay-by-check/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

 Add missing help text entry which is loggin an error in the log

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1. Without this patch no help text is present in the template page navigate to wp-admin/admin.php?page=pmpro-emailtemplates&edit=new_content
2. check the log. An error is logged.
3. With the patch it shouldn't and the help text is properly rendered

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
